### PR TITLE
fix: adjust imports from ".XXX" to "pypnnomenclature.XXX"

### DIFF
--- a/src/pypnnomenclature/admin.py
+++ b/src/pypnnomenclature/admin.py
@@ -4,8 +4,8 @@ from functools import partial
 from flask import has_app_context, g
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.contrib.sqla.filters import BaseSQLAFilter
-from .models import TNomenclatures, BibNomenclaturesTypes
-from .env import db
+from pypnnomenclature.models import TNomenclatures, BibNomenclaturesTypes
+from pypnnomenclature.env import db
 from sqlalchemy import select
 
 

--- a/src/pypnnomenclature/models.py
+++ b/src/pypnnomenclature/models.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import select, func
 from utils_flask_sqla.serializers import serializable
 
-from .env import db
+from pypnnomenclature.env import db
 
 
 @serializable

--- a/src/pypnnomenclature/repository.py
+++ b/src/pypnnomenclature/repository.py
@@ -5,7 +5,7 @@
 from importlib import import_module
 from flask import current_app
 
-from .models import (
+from pypnnomenclature.models import (
     TNomenclatures,
     BibNomenclaturesTypes,
     TNomenclatureTaxonomy,
@@ -14,7 +14,7 @@ from .models import (
 )
 from sqlalchemy import select, func
 
-from .env import db
+from pypnnomenclature.env import db
 
 
 def get_nomenclature_list(

--- a/src/pypnnomenclature/routes.py
+++ b/src/pypnnomenclature/routes.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, print_function, absolute_import, divisi
 from flask import Blueprint, request, jsonify
 from utils_flask_sqla.response import json_resp
 
-from . import repository
+from pypnnomenclature import repository
 
 
 routes = Blueprint("nomenclatures", __name__)

--- a/src/pypnnomenclature/utils.py
+++ b/src/pypnnomenclature/utils.py
@@ -2,8 +2,8 @@ from sqlalchemy import inspect
 from marshmallow_sqlalchemy.convert import ModelConverter
 from marshmallow.fields import Nested
 
-from .models import TNomenclatures as Nomenclature
-from .schemas import NomenclatureSchema
+from pypnnomenclature.models import TNomenclatures as Nomenclature
+from pypnnomenclature.schemas import NomenclatureSchema
 
 """
 This converter automatically add Nested(NomenclatureSchema) fields


### PR DESCRIPTION
On préfère ici utiliser le chemin d'import `pypnnomenclature.XXX` au lieu de `.XXX`

Le chemin introduit des confusions de chemins, par exemple lors de l'utilisation d'un debugger au niveau de l'appli GeoNature.